### PR TITLE
Add Copilot instructions for filmoteca repository

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,89 @@
+<HighLevelDetails>
+
+The `filmoteca` repository stores cultural data collections in three main folders:
+- `llibres/` → book entries
+- `pelicules/` → movie entries
+- `series/` → series entries
+
+Each folder contains a `README.md` that describes the exact format each entry must follow.  
+Each entry is a text file (usually `.md` or `.txt`) with fields such as title, author/director, year, etc.  
+The repository **does not contain any scripts or executable code** — only data files.
+
+Goal:
+- Enable Copilot to **verify that each entry file complies with the format specified in its README**.
+- Ensure that **no entries are duplicated** (same title, author, or file name).
+
+Project type: data collection.  
+Languages: Markdown / plain text.  
+No dependencies or compilation.  
+Repository is small and can be fully analyzed.
+
+</HighLevelDetails>
+
+<BuildInstructions>
+
+There is no build or execution process.  
+Copilot should analyze the files directly.
+
+Steps:
+1. Read the content of `README.md` files in `llibres/`, `pelicules/`, and `series/`.  
+   - These define the expected format for each entry type.
+2. Iterate through all files in each folder (excluding `README.md`).
+3. For each file:
+   - Check if the required fields specified by the corresponding README are present and in the correct order.
+   - Ensure the content is not empty or incomplete.
+4. Maintain a record of all titles, authors, and file names found.
+5. Verify that there are no duplicates among them.
+6. Report files with errors or inconsistencies.
+
+Do not execute any commands or create any scripts.  
+All verification should be done internally by Copilot's analysis.
+
+</BuildInstructions>
+
+<ProjectLayout>
+
+Typical project structure:
+
+filmoteca/
+├── llibres/
+│   ├── README.md          → specifies expected format for each book
+│   ├── llibre1.md
+│   ├── llibre2.md
+│   └── ...
+├── pelicules/
+│   ├── README.md          → specifies expected format for each movie
+│   ├── peli1.md
+│   └── ...
+├── series/
+│   ├── README.md          → specifies expected format for each series
+│   ├── serie1.md
+│   └── ...
+└── README.md              → general description of the project
+
+No source code or configuration files exist.  
+Validation relies solely on matching files to the formats documented in the `README.md`.
+
+</ProjectLayout>
+
+<StepsToFollow>
+
+1. Examine all contents of the `filmoteca` repository.
+2. Read all `README.md` files to understand the expected format for each type of entry.
+3. List all files in `llibres/`, `pelicules/`, and `series/` (ignoring `README.md`).
+4. For each file:
+   - Compare its content against the format specified in the corresponding README.
+   - Identify missing, incorrect, or misordered fields.
+5. Detect potential duplicates based on:
+   - title,
+   - file name,
+   - or other key fields defined in the README.
+6. Produce a report listing:
+   - Correct entries ✅
+   - Entries with format issues ⚠️ (indicating missing fields)
+   - Duplicate entries ❌ (indicating affected files)
+7. Do not generate or execute any code or modify any files.
+8. Use internal analysis of the repository. Only perform additional searches if the instructions are incomplete or contradictory.
+9. Treat the `README.md` files as the authoritative source for correct format.
+
+</StepsToFollow>


### PR DESCRIPTION
Added detailed instructions for Copilot to analyze the filmoteca repository, including project layout, build instructions, and steps for verifying entry compliance.