### PR TITLE
Pel·lícula: El laberint del faune

### DIFF
--- a/pelicules/el-laberint-del-faune.md
+++ b/pelicules/el-laberint-del-faune.md
@@ -1,0 +1,16 @@
+# El laberint del faune
+
+## Sinopsi
+Espanya, 1944. L'Ofèlia es trasllada amb la seua mare al casal d'un
+cruel capità franquista durant la postguerra. Allà descobreix un antic
+laberint on un faune li revela que és la princesa d'un regne subterrani
+i li encomana tres proves que haurà de superar per tornar-hi.
+
+## Gèneres
+- Fantasia fosca
+- Drama
+- Bèl·lica
+
+## Repartiment
+Dirigida per Guillermo del Toro. Amb Ivana Baquero, Sergi López,
+Maribel Verdú i Doug Jones.


### PR DESCRIPTION
Afegeixo una nova entrada a la base de dades de pel·lícules: **El laberint del faune** (Guillermo del Toro, 2006), dins del directori `pelicules/`.

El fitxer segueix el format indicat al README (Sinopsi, Gèneres i Repartiment) i està escrit en valencià/català. No duplica cap entrada existent.